### PR TITLE
Fixed (Issue #3) - Could not create an instance of type com.android.build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,19 @@ allprojects {
 }
 
 rootProject.buildDir = "../build"
+
+subprojects {
+    afterEvaluate { project ->
+        if (project.hasProperty('android')) {
+            project.android {
+                if (namespace == null) {
+                    namespace project.group
+                }
+            }
+        }
+    }
+}
+
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
 }


### PR DESCRIPTION
Did the fix for Issue  #3 


Fixed - Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl

Even though namespace was already mentioned in build.gradle, sometimes dependency issues can cause conflict with AGP 8+ version 

Solution : Added subproject in build.gradle, located right within the android folder, It will make all dependencies to use namespace